### PR TITLE
Rename ConfigurationProvider and suppress logs on inital read

### DIFF
--- a/example/src/main/java/com/dynatrace/metric/util/example/App.java
+++ b/example/src/main/java/com/dynatrace/metric/util/example/App.java
@@ -101,16 +101,22 @@ public class App {
 
   // to try this out, create the endpoint.properties file, start the app, and then modify the
   // contents of the file.
-  void testFilePolling() {
+  static void testFilePolling() {
     // file is at /var/lib/dynatrace/enrichment/endpoint/endpoint.properties
     final DynatraceFileBasedConfigurationProvider instance =
         DynatraceFileBasedConfigurationProvider.getInstance();
 
     int counter = 0;
     while (true) {
+
+      String token = instance.getMetricIngestToken();
       System.out.println(String.format("=============== %d ===============", counter++));
       System.out.println("Endpoint: " + instance.getMetricIngestEndpoint());
-      System.out.println("Token: " + instance.getMetricIngestToken());
+      System.out.println(
+          "Token:    "
+              + token.substring(
+                  0,
+                  Math.min(token.length(), 32))); // 32 chars = public portion only if actual token
       try {
         Thread.sleep(5000);
       } catch (InterruptedException e) {

--- a/example/src/main/java/com/dynatrace/metric/util/example/App.java
+++ b/example/src/main/java/com/dynatrace/metric/util/example/App.java
@@ -13,6 +13,7 @@
  */
 package com.dynatrace.metric.util.example;
 
+import com.dynatrace.file.util.DynatraceFileBasedConfigurationProvider;
 import com.dynatrace.metric.util.*;
 
 public class App {
@@ -95,6 +96,26 @@ public class App {
 
     } catch (MetricException me) {
       System.out.println(me);
+    }
+  }
+
+  // to try this out, create the endpoint.properties file, start the app, and then modify the
+  // contents of the file.
+  void testFilePolling() {
+    // file is at /var/lib/dynatrace/enrichment/endpoint/endpoint.properties
+    final DynatraceFileBasedConfigurationProvider instance =
+        DynatraceFileBasedConfigurationProvider.getInstance();
+
+    int counter = 0;
+    while (true) {
+      System.out.println(String.format("=============== %d ===============", counter++));
+      System.out.println("Endpoint: " + instance.getMetricIngestEndpoint());
+      System.out.println("Token: " + instance.getMetricIngestToken());
+      try {
+        Thread.sleep(5000);
+      } catch (InterruptedException e) {
+        System.out.println("Exiting...");
+      }
     }
   }
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 group 'com.dynatrace.metric.util'
-version = '1.3.0'
+version = '1.3.1'
 
 repositories {
     mavenCentral()

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 group 'com.dynatrace.metric.util'
-version = '1.3.1'
+version = '1.3.0'
 
 repositories {
     mavenCentral()

--- a/lib/src/main/java/com/dynatrace/file/util/DynatraceConfiguration.java
+++ b/lib/src/main/java/com/dynatrace/file/util/DynatraceConfiguration.java
@@ -2,7 +2,7 @@ package com.dynatrace.file.util;
 
 import com.dynatrace.metric.util.DynatraceMetricApiConstants;
 
-class DynatraceMetricsConfiguration {
+class DynatraceConfiguration {
   private String metricIngestEndpoint = DynatraceMetricApiConstants.getDefaultOneAgentEndpoint();
   private String metricIngestToken = "";
 

--- a/lib/src/main/java/com/dynatrace/file/util/DynatraceFileBasedConfigurationProvider.java
+++ b/lib/src/main/java/com/dynatrace/file/util/DynatraceFileBasedConfigurationProvider.java
@@ -7,32 +7,32 @@ import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-public class DynatraceFileBasedMetricConfigurationProvider {
+public class DynatraceFileBasedConfigurationProvider {
   // Lazy loading singleton instance.
   private static class ProviderHolder {
-    private static final DynatraceFileBasedMetricConfigurationProvider INSTANCE =
-        new DynatraceFileBasedMetricConfigurationProvider(PROPERTIES_FILENAME);
+    private static final DynatraceFileBasedConfigurationProvider INSTANCE =
+        new DynatraceFileBasedConfigurationProvider(PROPERTIES_FILENAME);
   }
 
-  private DynatraceFileBasedMetricConfigurationProvider(String fileName) {
+  private DynatraceFileBasedConfigurationProvider(String fileName) {
     setUp(fileName);
   }
 
   private static final Logger logger =
-      Logger.getLogger(DynatraceFileBasedMetricConfigurationProvider.class.getName());
+      Logger.getLogger(DynatraceFileBasedConfigurationProvider.class.getName());
 
   private static final String PROPERTIES_FILENAME =
       "/var/lib/dynatrace/enrichment/endpoint/endpoint.properties";
 
   private FilePoller filePoller;
-  private DynatraceMetricsConfiguration config;
+  private DynatraceConfiguration config;
 
-  public static DynatraceFileBasedMetricConfigurationProvider getInstance() {
+  public static DynatraceFileBasedConfigurationProvider getInstance() {
     return ProviderHolder.INSTANCE;
   }
 
   private void setUp(String fileName) {
-    config = new DynatraceMetricsConfiguration();
+    config = new DynatraceConfiguration();
     FilePoller poller = null;
     try {
       if (!Files.exists(Paths.get(fileName))) {

--- a/lib/src/main/java/com/dynatrace/file/util/DynatraceFileBasedConfigurationProvider.java
+++ b/lib/src/main/java/com/dynatrace/file/util/DynatraceFileBasedConfigurationProvider.java
@@ -14,7 +14,7 @@ public class DynatraceFileBasedConfigurationProvider {
         new DynatraceFileBasedConfigurationProvider(PROPERTIES_FILENAME);
   }
 
-  // this is used so on the initial read no logs will be printed
+  // avoid printing logs on the initial read
   private boolean alreadyInitialized = false;
 
   private DynatraceFileBasedConfigurationProvider(String fileName) {

--- a/lib/src/main/java/com/dynatrace/file/util/DynatraceFileBasedConfigurationProvider.java
+++ b/lib/src/main/java/com/dynatrace/file/util/DynatraceFileBasedConfigurationProvider.java
@@ -14,6 +14,9 @@ public class DynatraceFileBasedConfigurationProvider {
         new DynatraceFileBasedConfigurationProvider(PROPERTIES_FILENAME);
   }
 
+  // this is used so on the initial read no logs will be printed
+  private boolean alreadyInitialized = false;
+
   private DynatraceFileBasedConfigurationProvider(String fileName) {
     setUp(fileName);
   }
@@ -32,6 +35,7 @@ public class DynatraceFileBasedConfigurationProvider {
   }
 
   private void setUp(String fileName) {
+    alreadyInitialized = false;
     config = new DynatraceConfiguration();
     FilePoller poller = null;
     try {
@@ -81,6 +85,7 @@ public class DynatraceFileBasedConfigurationProvider {
         config.setMetricIngestToken(newToken);
       }
 
+      alreadyInitialized = true;
     } catch (IOException e) {
       logger.info("Failed reading properties from file.");
     }
@@ -98,7 +103,9 @@ public class DynatraceFileBasedConfigurationProvider {
       return null;
     }
     if (!newToken.equals(config.getMetricIngestToken())) {
-      logger.info("API Token refreshed.");
+      if (alreadyInitialized) {
+        logger.info("API Token refreshed.");
+      }
       return newToken;
     }
     return null;
@@ -117,7 +124,9 @@ public class DynatraceFileBasedConfigurationProvider {
       return null;
     }
     if (!newEndpoint.equals(config.getMetricIngestEndpoint())) {
-      logger.info(() -> String.format("Read new endpoint: %s", newEndpoint));
+      if (alreadyInitialized) {
+        logger.info(() -> String.format("Read new endpoint: %s", newEndpoint));
+      }
       return newEndpoint;
     }
     return null;

--- a/lib/src/test/java/com/dynatrace/file/util/DynatraceFileBasedConfigurationProviderTest.java
+++ b/lib/src/test/java/com/dynatrace/file/util/DynatraceFileBasedConfigurationProviderTest.java
@@ -9,13 +9,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 
-class DynatraceFileBasedMetricConfigurationProviderTest {
+class DynatraceFileBasedConfigurationProviderTest {
   // We rely on the fact that JUnit runs tests in series, not parallel.
 
   @Test
   void testNonExistentFileReturnsDefaults() {
-    final DynatraceFileBasedMetricConfigurationProvider instance =
-        DynatraceFileBasedMetricConfigurationProvider.getInstance();
+    final DynatraceFileBasedConfigurationProvider instance =
+        DynatraceFileBasedConfigurationProvider.getInstance();
     // Set up test
     instance.forceOverwriteConfig(TestUtils.generateNonExistentFilename());
 
@@ -27,8 +27,8 @@ class DynatraceFileBasedMetricConfigurationProviderTest {
 
   @Test
   void testFileExistsButDoesNotContainRequiredProps_shouldReturnDefault() {
-    final DynatraceFileBasedMetricConfigurationProvider instance =
-        DynatraceFileBasedMetricConfigurationProvider.getInstance();
+    final DynatraceFileBasedConfigurationProvider instance =
+        DynatraceFileBasedConfigurationProvider.getInstance();
     // Set up test
     instance.forceOverwriteConfig("src/test/resources/config_invalid.properties");
 
@@ -40,8 +40,8 @@ class DynatraceFileBasedMetricConfigurationProviderTest {
 
   @Test
   void testFileExistsAndContainsValidProps() {
-    final DynatraceFileBasedMetricConfigurationProvider instance =
-        DynatraceFileBasedMetricConfigurationProvider.getInstance();
+    final DynatraceFileBasedConfigurationProvider instance =
+        DynatraceFileBasedConfigurationProvider.getInstance();
     // Set up test
     instance.forceOverwriteConfig("src/test/resources/config_valid.properties");
 
@@ -61,8 +61,8 @@ class DynatraceFileBasedMetricConfigurationProviderTest {
     // wait for the nonblocking io to finish writing.
     Thread.sleep(10);
 
-    final DynatraceFileBasedMetricConfigurationProvider instance =
-        DynatraceFileBasedMetricConfigurationProvider.getInstance();
+    final DynatraceFileBasedConfigurationProvider instance =
+        DynatraceFileBasedConfigurationProvider.getInstance();
     // Set up test
     instance.forceOverwriteConfig(tempfile.toString());
 


### PR DESCRIPTION
Removes the restriction of the ConfigurationProvider to metrics, in order to be able to add configuration for other signals in the future, if required.