### PR TITLE
Memory (churn) performance optimization in Normalize class

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 group 'com.dynatrace.metric.util'
-version = '1.3.0'
+version = '1.4.0'
 
 repositories {
     mavenCentral()

--- a/lib/src/main/java/com/dynatrace/metric/util/Normalize.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/Normalize.java
@@ -178,6 +178,11 @@ final class Normalize {
   }
 
   static String escapeDimensionValue(String val) {
+    if (isNullOrEmpty(val)) {
+      logger.warning("null or empty dimension value passed to normalization.");
+      return val;
+    }
+
     // Fast pass: Only escape if escaping is actually necessary
     if (!needToEscapeDimensionValue(val)) {
       return val;

--- a/lib/src/main/java/com/dynatrace/metric/util/Normalize.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/Normalize.java
@@ -46,7 +46,21 @@ final class Normalize {
 
   // Dimension values (dv)
   // Characters that need to be escaped in dimension values
-  private static final Pattern re_dv_charactersToEscape = Pattern.compile("([= ,\\\\])");
+  private static final char dv_characterToEscape_quote = '"';
+  private static final char dv_characterToEscape_equals = '=';
+  private static final char dv_characterToEscape_blank = ' ';
+  private static final char dv_characterToEscape_comma = ',';
+  private static final char dv_characterToEscape_backslash = '\\';
+  private static final String dv_charactersToEscape =
+      new StringBuilder(5)
+          .append(dv_characterToEscape_quote)
+          .append(dv_characterToEscape_equals)
+          .append(dv_characterToEscape_blank)
+          .append(dv_characterToEscape_comma)
+          .append(dv_characterToEscape_backslash)
+          .toString();
+  private static final Pattern re_dv_charactersToEscape =
+      Pattern.compile("([" + Pattern.quote(dv_charactersToEscape) + "])");
   private static final Pattern re_dv_controlCharacters = Pattern.compile("[\\p{C}]+");
 
   // This regex checks if there is an odd number of trailing backslashes in the string. It can be
@@ -136,7 +150,39 @@ final class Normalize {
     return value;
   }
 
+  /**
+   * Fast check: Does the dimension value need to be escaped at all?
+   *
+   * @param dimensionValue The dimension value
+   * @return True if it contains characters that need to be escaped according to the Dynatrace
+   *     metrics ingestion protocol, false otherwise.
+   */
+  static boolean needToEscapeDimensionValue(String dimensionValue) {
+    int len = dimensionValue.length();
+    if (len > dv_max_length) {
+      return true;
+    }
+
+    for (int i = 0; i < len; i++) {
+      char c = dimensionValue.charAt(i);
+      if (c == dv_characterToEscape_quote
+          || c == dv_characterToEscape_equals
+          || c == dv_characterToEscape_blank
+          || c == dv_characterToEscape_comma
+          || c == dv_characterToEscape_backslash) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   static String escapeDimensionValue(String val) {
+    // Fast pass: Only escape if escaping is actually necessary
+    if (!needToEscapeDimensionValue(val)) {
+      return val;
+    }
+
     // escape characters matched by regex with backslash. $1 inserts the matched character.
     String escaped = re_dv_charactersToEscape.matcher(val).replaceAll("\\\\$1");
     if (escaped.length() > dv_max_length) {

--- a/lib/src/test/java/com/dynatrace/metric/util/NormalizeTest.java
+++ b/lib/src/test/java/com/dynatrace/metric/util/NormalizeTest.java
@@ -266,7 +266,9 @@ public class NormalizeTest {
         Arguments.of(
             "dimension value of only backslashes",
             repeatStringNTimes("\\", 260),
-            repeatStringNTimes("\\\\", 125)));
+            repeatStringNTimes("\\\\", 125)),
+        Arguments.of("Null must not fail", null, null),
+        Arguments.of("Empty must not fail", "", ""));
   }
 
   private static Stream<Arguments> provideNeedToEscapeDimensionValue() {

--- a/lib/src/test/java/com/dynatrace/metric/util/NormalizeTest.java
+++ b/lib/src/test/java/com/dynatrace/metric/util/NormalizeTest.java
@@ -48,6 +48,12 @@ public class NormalizeTest {
     assertEquals(expected, Normalize.escapeDimensionValue(input));
   }
 
+  @ParameterizedTest(name = "{index}: {0}, input: {1}, expected: {2}")
+  @MethodSource("provideNeedToEscapeDimensionValue")
+  public void testNeedToEscapeDimensionValue(String name, String input, boolean expected) {
+    assertEquals(expected, Normalize.needToEscapeDimensionValue(input));
+  }
+
   @Test
   public void testDimensionValuesEscapedOnlyOnce() throws MetricException {
     MetricBuilderFactory metricBuilderFactory = MetricBuilderFactory.builder().build();
@@ -232,14 +238,15 @@ public class NormalizeTest {
 
   private static Stream<Arguments> provideToEscapeValues() {
     return Stream.of(
+        Arguments.of("unescaped", "ab", "ab"),
         Arguments.of("escape spaces", "a b", "a\\ b"),
         Arguments.of("escape comma", "a,b", "a\\,b"),
         Arguments.of("escape equals", "a=b", "a\\=b"),
         Arguments.of("escape backslash", "a\\b", "a\\\\b"),
-        Arguments.of("escape multiple special chars", " ,=\\", "\\ \\,\\=\\\\"),
+        Arguments.of("escape multiple special chars", "\" ,=\\", "\\\"\\ \\,\\=\\\\"),
         Arguments.of(
             "escape consecutive special chars", "  ,,==\\\\", "\\ \\ \\,\\,\\=\\=\\\\\\\\"),
-        Arguments.of("escape key-value pair", "key=\"value\"", "key\\=\"value\""),
+        Arguments.of("escape key-value pair", "key=\"value\"", "key\\=\\\"value\\\""),
         Arguments.of(
             "escape too long string", repeatStringNTimes("=", 250), repeatStringNTimes("\\=", 125)),
         Arguments.of(
@@ -260,5 +267,20 @@ public class NormalizeTest {
             "dimension value of only backslashes",
             repeatStringNTimes("\\", 260),
             repeatStringNTimes("\\\\", 125)));
+  }
+
+  private static Stream<Arguments> provideNeedToEscapeDimensionValue() {
+    return Stream.of(
+        Arguments.of("quote", "a\"b", true),
+        Arguments.of("space", "a b", true),
+        Arguments.of("comma", "a,b", true),
+        Arguments.of("equals", "a=b", true),
+        Arguments.of("backslash", "a\\b", true),
+        Arguments.of("need to escape multiple", "a\"b c,d=e\\f", true),
+        Arguments.of(
+            "no need to escape: a-Z",
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+            false),
+        Arguments.of("no need to escape: other", "_-", false));
   }
 }


### PR DESCRIPTION
Memory (churn) performance optimization: Added Normalize.needToEscapeDimensionValue check to only perform the regex escaping / string replacement if required.

Resolves #23.