### PR TITLE
Replace custom parser with Properties.load()

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.java]
+indent_style = space
+indent_size = 2

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -24,7 +24,6 @@ version = '1.4.0'
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {

--- a/lib/src/main/java/com/dynatrace/metric/util/DynatraceMetadataEnricher.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/DynatraceMetadataEnricher.java
@@ -11,76 +11,60 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.dynatrace.metric.util;
 
 import java.io.*;
 import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 class DynatraceMetadataEnricher {
   private static final Logger logger = Logger.getLogger(DynatraceMetadataEnricher.class.getName());
 
   private static final String INDIRECTION_FILE_NAME =
-      "dt_metadata_e617c525669e072eebe3d0f08212e8f2.properties";
+    "dt_metadata_e617c525669e072eebe3d0f08212e8f2.properties";
 
   private static final String ALTERNATIVE_METADATA_FILENAME =
-      "/var/lib/dynatrace/enrichment/dt_metadata.properties";
+    "/var/lib/dynatrace/enrichment/dt_metadata.properties";
 
   /**
    * Retrieve Dynatrace metadata. Attempts to read from the indirection file, and falls back to the
    * alternative metadata file if the primary source is not available.
    *
    * @return A list of not yet normalized {@link Dimension} objects. Items with no equal sign, or
-   *     with empty key or value are discarded.
+   * with empty key or value are discarded.
    */
   static List<Dimension> getDynatraceMetadata() {
-    return parseDynatraceMetadata(
-        getMetadataFileContentWithRedirection(
-            INDIRECTION_FILE_NAME, ALTERNATIVE_METADATA_FILENAME));
+    return createDimensionList(
+      getPropertiesWithIndirection(
+        INDIRECTION_FILE_NAME, ALTERNATIVE_METADATA_FILENAME));
   }
 
   /**
-   * This function takes a list of strings from the Dynatrace metadata file and transforms it into a
-   * list of {@link Dimension} objects. Parsing failures will not be added to the output list.
-   * Therefore, it is possible that the output list is shorter than the input, or even empty.
+   * This function takes {@link Properties} object and transforms it into a {@link List<Dimension>}.
    *
-   * @param lines a {@link List<String>} containing key-value pairs (as one string) separated by an
-   *     equal sign.
+   * @param properties {@link Properties} to transform
    * @return A {@link List} of {@link Dimension dimensions} mapping {@link String} to {@link
-   *     String}. These represent the the lines passed in separated by the first occurring equal
-   *     sign on each line, respectively. If no line is parsable, returns an empty list. Dimensions
-   *     are not normalized.
+   * String}. These represent the property entries, where empty keys or values were omitted.
    */
-  static List<Dimension> parseDynatraceMetadata(Collection<String> lines) {
+  static List<Dimension> createDimensionList(Properties properties) {
     ArrayList<Dimension> entries = new ArrayList<>();
 
-    // iterate all lines from metadata file.
-    for (String line : lines) {
-      logger.fine(String.format("parsing Dynatrace metadata: %s", line));
-      // if there are more than one '=' in the line, split only at the first one.
-      String[] split = line.split("=", 2);
+    for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+      String key = entry.getKey().toString();
+      String value = entry.getValue().toString();
 
-      // skip if there is no '=' in the line
-      if (split.length != 2) {
-        logger.warning(String.format("could not parse metadata line ('%s')", line));
+      // make sure key and value are set to non-empty values
+      if (key.isEmpty() || value.isEmpty()){
+        logger.log(Level.WARNING, () -> String.format("dropped settings %s=%s", key, value));
         continue;
       }
 
-      String key = split[0];
-      String value = split[1];
-
-      // make sure key and value are set to non-null, non-empty values
-      if ((key == null || key.isEmpty()) || (value == null || value.isEmpty())) {
-        logger.warning(String.format("could not parse metadata line ('%s')", line));
-        continue;
-      }
-      entries.add(Dimension.create(key, value));
+      entries.add(Dimension.create(entry.getKey().toString(), entry.getValue().toString()));
     }
+
     return entries;
   }
 
@@ -108,22 +92,6 @@ class DynatraceMetadataEnricher {
   }
 
   /**
-   * Read the actual content of the metadata file.
-   *
-   * @param fileContents A {@link Reader} object containing the metadata contents.
-   * @return A {@link List<String>} containing the {@link String#trim() trimmed} lines.
-   * @throws IOException if an error occurs during reading of the file.
-   */
-  static List<String> getDynatraceMetadataFileContents(Reader fileContents) throws IOException {
-    if (fileContents == null) {
-      throw new IOException("passed Reader cannot be null.");
-    }
-    try (BufferedReader reader = new BufferedReader(fileContents)) {
-      return reader.lines().map(String::trim).collect(Collectors.toList());
-    }
-  }
-
-  /**
    * A helper function that returns whether file exists and is readable.
    *
    * @param filePath The path to the file.
@@ -142,15 +110,15 @@ class DynatraceMetadataEnricher {
   }
 
   /**
-   * Gets the file location of the metadata file from the indirection file and reads the contents
-   * thereof. If the indirection file does not exist, falls back to the alternative metadata file.
+   * Gets the {@link Properties} contained in the metadata file from the indirection file
+   * If the indirection file does not exist, falls back to the alternative metadata file.
    *
-   * @return A {@link List<String>} representing the contents of the Dynatrace metadata file.
-   *     Leading and trailing whitespaces are {@link String#trim() trimmed} for each of the lines.
+   * @return The {@link Properties} contained in the Dynatrace metadata file.
    */
-  static List<String> getMetadataFileContentWithRedirection(
-      String indirectionFileName, String alternativeMetadataFilename) {
+  static Properties getPropertiesWithIndirection(
+    String indirectionFileName, String alternativeMetadataFilename) {
     String metadataFileName = null;
+    Properties props = new Properties();
 
     try (Reader indirectionFileReader = new FileReader(indirectionFileName)) {
       metadataFileName = getMetadataFileName(indirectionFileReader);
@@ -158,32 +126,31 @@ class DynatraceMetadataEnricher {
       logger.info("Indirection file not found. This is normal if OneAgent is not installed.");
     } catch (Exception e) {
       logger.info(
-          String.format("Error while trying to read contents of OneAgent indirection file: %s", e));
+        String.format("Error while trying to read contents of OneAgent indirection file: %s", e));
     }
 
     if (metadataFileName == null || metadataFileName.isEmpty()) {
       if (DynatraceMetadataEnricher.fileExistsAndIsReadable(alternativeMetadataFilename)) {
         // alternative file exists, use it for metadata enrichment
-        logger.info(
-            String.format(
-                "Alternative metadata file exists, attempting to read from %s.",
-                alternativeMetadataFilename));
+        logger.log(Level.INFO, () -> String.format(
+          "Alternative metadata file exists, attempting to read from %s.",
+          alternativeMetadataFilename));
         metadataFileName = alternativeMetadataFilename;
       } else {
-        // no alternative file exists, return an empty list.
-        return Collections.emptyList();
+        // no alternative file exists, return empty properties.
+        return props;
       }
     }
 
-    List<String> properties = Collections.emptyList();
-    try (Reader metadataFileReader = new FileReader(metadataFileName)) {
-      properties = getDynatraceMetadataFileContents(metadataFileReader);
+    try (Reader reader = new FileReader(metadataFileName)) {
+      props.load(reader);
     } catch (FileNotFoundException e) {
       logger.warning("Failed to read properties file: File not found");
     } catch (Exception e) {
       logger.info(
-          String.format("Error while trying to read contents of Dynatrace metadata file: %s", e));
+        String.format("Error while trying to read contents of Dynatrace metadata file: %s", e));
     }
-    return properties;
+
+    return props;
   }
 }

--- a/lib/src/main/java/com/dynatrace/metric/util/DynatraceMetadataEnricher.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/DynatraceMetadataEnricher.java
@@ -48,6 +48,7 @@ class DynatraceMetadataEnricher {
    * @param properties {@link Properties} to transform
    * @return A {@link List} of {@link Dimension dimensions} mapping {@link String} to {@link
    * String}. These represent the property entries, where empty keys or values were omitted.
+   * Dimensions are not normalized.
    */
   static List<Dimension> createDimensionList(Properties properties) {
     ArrayList<Dimension> entries = new ArrayList<>();
@@ -56,7 +57,7 @@ class DynatraceMetadataEnricher {
       String key = entry.getKey().toString();
       String value = entry.getValue().toString();
 
-      // make sure key and value are set to non-empty values
+      // skip if either key or value are empty
       if (key.isEmpty() || value.isEmpty()){
         logger.log(Level.WARNING, () -> String.format("dropped settings %s=%s", key, value));
         continue;

--- a/lib/src/test/java/com/dynatrace/metric/util/DynatraceMetadataEnricherTest.java
+++ b/lib/src/test/java/com/dynatrace/metric/util/DynatraceMetadataEnricherTest.java
@@ -105,7 +105,7 @@ class DynatraceMetadataEnricherTest {
   }
 
   @Test
-  void testGetMetadataFileContentWithRedirection_Valid() {
+  void testGetPropertiesWithIndirection_Valid() {
     // this should not be used. If it is, it will not exist and throw an exception, breaking the
     // test.
     String nonExistentAlternativeFilename = generateNonExistentFilename();
@@ -123,7 +123,7 @@ class DynatraceMetadataEnricherTest {
   }
 
   @Test
-  void testGetMetadataFileContentWithRedirection_IndirectionFileDoesNotExistAlternativeDoesNotExist() {
+  void testGetPropertiesWithIndirection_IndirectionFileDoesNotExistAlternativeDoesNotExist() {
     String filename = generateNonExistentFilename();
     String alternativeFilename = generateNonExistentFilename();
 
@@ -134,7 +134,7 @@ class DynatraceMetadataEnricherTest {
   }
 
   @Test
-  void testGetMetadataFileContentWithRedirection_IndirectionFileDoesNotExistAlternativeExists() {
+  void testGetPropertiesWithIndirection_IndirectionFileDoesNotExistAlternativeExists() {
     String filename = generateNonExistentFilename();
 
     Properties result =
@@ -151,7 +151,7 @@ class DynatraceMetadataEnricherTest {
   }
 
   @Test
-  void testGetMetadataFileContentWithRedirection_IndirectionFileReturnsNullAndAlternativeDoesNotExist() {
+  void testGetPropertiesWithIndirection_IndirectionFileReturnsNullAndAlternativeDoesNotExist() {
     try (MockedStatic<DynatraceMetadataEnricher> mockEnricher =
         Mockito.mockStatic(DynatraceMetadataEnricher.class)) {
       mockEnricher
@@ -179,7 +179,7 @@ class DynatraceMetadataEnricherTest {
   }
 
   @Test
-  void testGetMetadataFileContentWithRedirection_IndirectionFileReturnsNullAndAlternativeDoesExist() {
+  void testGetPropertiesWithIndirection_IndirectionFileReturnsNullAndAlternativeDoesExist() {
     try (MockedStatic<DynatraceMetadataEnricher> mockEnricher =
         Mockito.mockStatic(DynatraceMetadataEnricher.class)) {
       mockEnricher
@@ -212,7 +212,7 @@ class DynatraceMetadataEnricherTest {
   }
 
   @Test
-  void testGetMetadataFileContentWithRedirection_IndirectionFileReturnsEmptyAndAlternativeDoesNotExist() {
+  void testGetPropertiesWithIndirection_IndirectionFileReturnsEmptyAndAlternativeDoesNotExist() {
     try (MockedStatic<DynatraceMetadataEnricher> mockEnricher =
         Mockito.mockStatic(DynatraceMetadataEnricher.class)) {
       // ignore the return value of the testfile and mock the return value of the
@@ -242,7 +242,7 @@ class DynatraceMetadataEnricherTest {
   }
 
   @Test
-  void testGetMetadataFileContentWithRedirection_IndirectionFileReturnsEmptyAndAlternativeDoesExist() {
+  void testGetPropertiesWithIndirection_IndirectionFileReturnsEmptyAndAlternativeDoesExist() {
     try (MockedStatic<DynatraceMetadataEnricher> mockEnricher =
         Mockito.mockStatic(DynatraceMetadataEnricher.class)) {
       mockEnricher
@@ -274,7 +274,7 @@ class DynatraceMetadataEnricherTest {
   }
 
   @Test
-  void testGetMetadataFileContentWithRedirection_IndirectionFileThrowsAndAlternativeDoesNotExist() {
+  void testGetPropertiesWithIndirection_IndirectionFileThrowsAndAlternativeDoesNotExist() {
     try (MockedStatic<DynatraceMetadataEnricher> mockEnricher =
         Mockito.mockStatic(DynatraceMetadataEnricher.class)) {
       // ignore the return value of the testfile and mock the return value of the
@@ -304,7 +304,7 @@ class DynatraceMetadataEnricherTest {
   }
 
   @Test
-  void testGetMetadataFileContentWithRedirection_IndirectionFileThrowsAndAlternativeDoesExist() {
+  void testGetPropertiesWithIndirection_IndirectionFileThrowsAndAlternativeDoesExist() {
     try (MockedStatic<DynatraceMetadataEnricher> mockEnricher =
         Mockito.mockStatic(DynatraceMetadataEnricher.class)) {
       mockEnricher
@@ -337,7 +337,7 @@ class DynatraceMetadataEnricherTest {
   }
 
   @Test
-  void testGetMetadataFileContentWithRedirection_MetadataFileDoesNotExist() {
+  void testGetPropertiesWithIndirection_MetadataFileDoesNotExist() {
     String metadataFilename = generateNonExistentFilename();
     try (MockedStatic<DynatraceMetadataEnricher> mockEnricher =
         Mockito.mockStatic(DynatraceMetadataEnricher.class)) {
@@ -370,7 +370,7 @@ class DynatraceMetadataEnricherTest {
   }
 
   @Test
-  void testGetMetadataFileContentWithRedirection_EmptyMetadataFile() {
+  void testGetPropertiesWithIndirection_EmptyMetadataFile() {
     try (MockedStatic<DynatraceMetadataEnricher> mockEnricher =
         Mockito.mockStatic(DynatraceMetadataEnricher.class)) {
       mockEnricher

--- a/lib/src/test/java/com/dynatrace/metric/util/DynatraceMetadataEnricherTest.java
+++ b/lib/src/test/java/com/dynatrace/metric/util/DynatraceMetadataEnricherTest.java
@@ -19,50 +19,72 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-public class DynatraceMetadataEnricherTest {
+class DynatraceMetadataEnricherTest {
 
   @Test
-  public void validMetrics() {
+  void validProperties() {
+    Properties properties = new Properties();
+    properties.setProperty("prop.a", "value.a");
+    properties.setProperty("prop.b", "value.b");
+
     ArrayList<Dimension> entries =
         new ArrayList<>(
-            DynatraceMetadataEnricher.parseDynatraceMetadata(
-                Arrays.asList("prop.a=value.a", "prop.b=value.b")));
+            DynatraceMetadataEnricher.createDimensionList(properties));
 
-    assertEquals("prop.a", entries.get(0).getKey());
-    assertEquals("value.a", entries.get(0).getValue());
-    assertEquals("prop.b", entries.get(1).getKey());
-    assertEquals("value.b", entries.get(1).getValue());
+    // Has one entry with key "prop.a"
+    assertEquals(1, entries.stream()
+      .filter(entry -> entry.getKey().equals("prop.a"))
+      .count());
+
+    // Entry with key "prop.a" has value "value.a"
+    assertEquals("value.a", entries.stream()
+      .filter(entry -> entry.getKey().equals("prop.a"))
+      .findFirst()
+      .get()
+      .getValue());
+
+    // Has one entry with key "prop.p"
+    assertEquals(1, entries
+      .stream()
+      .filter(entry -> entry.getKey().equals("prop.b"))
+      .count());
+
+    // Entry with key "prop.b" has value "value.b"
+    assertEquals("value.b", entries.stream()
+      .filter(entry -> entry.getKey().equals("prop.b"))
+      .findFirst()
+      .get()
+      .getValue());
   }
 
   @Test
-  public void invalidMetrics() {
+  void invalidProperties() {
+    Properties noValueProperties = new Properties();
+    noValueProperties.setProperty("key_no_value", "");
     assertTrue(
-        DynatraceMetadataEnricher.parseDynatraceMetadata(Collections.singletonList("key_no_value="))
-            .isEmpty());
+      DynatraceMetadataEnricher.createDimensionList(noValueProperties)
+        .isEmpty());
+
+    Properties noKeyProperties = new Properties();
+    noKeyProperties.setProperty("", "value_no_key");
     assertTrue(
-        DynatraceMetadataEnricher.parseDynatraceMetadata(Collections.singletonList("=value_no_key"))
-            .isEmpty());
+      DynatraceMetadataEnricher.createDimensionList(noKeyProperties)
+        .isEmpty());
+
+    Properties noKeyAndValueProperties = new Properties();
+    noKeyAndValueProperties.setProperty("","");
     assertTrue(
-        DynatraceMetadataEnricher.parseDynatraceMetadata(
-                Collections.singletonList("==============="))
-            .isEmpty());
-    assertTrue(
-        DynatraceMetadataEnricher.parseDynatraceMetadata(Collections.singletonList("")).isEmpty());
-    assertTrue(
-        DynatraceMetadataEnricher.parseDynatraceMetadata(Collections.singletonList("=")).isEmpty());
-    assertTrue(DynatraceMetadataEnricher.parseDynatraceMetadata(Collections.emptyList()).isEmpty());
+      DynatraceMetadataEnricher.createDimensionList(noKeyAndValueProperties).isEmpty());
   }
 
   @Test
-  public void testGetIndirectionFileContentValid() throws IOException {
+  void testGetIndirectionFileContentValid() throws IOException {
     String expected =
         "dt_metadata_e617c525669e072eebe3d0f08212e8f2_private_target_file_specifier.properties";
     // "mock" the contents of dt_metadata_e617c525669e072eebe3d0f08212e8f2.properties
@@ -72,96 +94,64 @@ public class DynatraceMetadataEnricherTest {
   }
 
   @Test
-  public void testGetIndirectionFilePassNull() {
+  void testGetIndirectionFilePassNull() {
     assertThrows(IOException.class, () -> DynatraceMetadataEnricher.getMetadataFileName(null));
   }
 
   @Test
-  public void testGetIndirectionFileContentEmptyContent() throws IOException {
+  void testGetIndirectionFileContentEmptyContent() throws IOException {
     StringReader reader = new StringReader("");
     assertNull(DynatraceMetadataEnricher.getMetadataFileName(reader));
   }
 
   @Test
-  public void testGetDynatraceMetadataFileContentValid() throws IOException {
-    List<String> expected = new ArrayList<>();
-    expected.add("key1=value1");
-    expected.add("key2=value2");
-    expected.add("key3=value3");
-
-    StringReader reader = new StringReader(String.join("\n", expected));
-    List<String> result = DynatraceMetadataEnricher.getDynatraceMetadataFileContents(reader);
-    assertEquals(expected, result);
-    assertNotSame(expected, result);
-  }
-
-  @Test
-  public void testGetDynatraceMetadataFileContentInvalid() throws IOException {
-    List<String> inputs = Arrays.asList("=0", "", "a=", "\t\t", "=====", "    ", "   test   ");
-    List<String> expected = Arrays.asList("=0", "", "a=", "", "=====", "", "test");
-
-    StringReader reader = new StringReader(String.join("\n", inputs));
-    List<String> result = DynatraceMetadataEnricher.getDynatraceMetadataFileContents(reader);
-    assertEquals(expected, result);
-    assertNotSame(expected, result);
-  }
-
-  @Test
-  public void testGetDynatraceMetadataFileContentEmptyFile() throws IOException {
-    List<String> expected = new ArrayList<>();
-
-    List<String> result =
-        DynatraceMetadataEnricher.getDynatraceMetadataFileContents(new StringReader(""));
-    assertEquals(expected, result);
-    assertNotSame(expected, result);
-  }
-
-  @Test
-  public void testGetDynatraceMetadataFileContentPassNull() {
-    assertThrows(
-        IOException.class, () -> DynatraceMetadataEnricher.getDynatraceMetadataFileContents(null));
-  }
-
-  @Test
-  public void testGetMetadataFileContentWithRedirection_Valid() {
+  void testGetMetadataFileContentWithRedirection_Valid() {
     // this should not be used. If it is, it will not exist and throw an exception, breaking the
     // test.
     String nonExistentAlternativeFilename = generateNonExistentFilename();
-    List<String> expected = Arrays.asList("key1=value1", "key2=value2", "key3=value3");
-    List<String> results =
-        DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
+    Properties expected = new Properties();
+    expected.setProperty("key1", "value1");
+    expected.setProperty("key2", "value2");
+    expected.setProperty("key3", "value3");
+
+
+    Properties results =
+        DynatraceMetadataEnricher.getPropertiesWithIndirection(
             "src/test/resources/indirection.properties", nonExistentAlternativeFilename);
     assertEquals(expected, results);
     assertNotSame(expected, results);
   }
 
   @Test
-  public void
-      testGetMetadataFileContentWithRedirection_IndirectionFileDoesNotExistAlternativeDoesNotExist() {
+  void testGetMetadataFileContentWithRedirection_IndirectionFileDoesNotExistAlternativeDoesNotExist() {
     String filename = generateNonExistentFilename();
     String alternativeFilename = generateNonExistentFilename();
 
-    List<String> result =
-        DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
+    Properties result =
+        DynatraceMetadataEnricher.getPropertiesWithIndirection(
             filename, alternativeFilename);
-    assertEquals(Collections.<String>emptyList(), result);
+    assertEquals(new Properties(), result);
   }
 
   @Test
-  public void
-      testGetMetadataFileContentWithRedirection_IndirectionFileDoesNotExistAlternativeExists() {
+  void testGetMetadataFileContentWithRedirection_IndirectionFileDoesNotExistAlternativeExists() {
     String filename = generateNonExistentFilename();
 
-    List<String> result =
-        DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
+    Properties result =
+        DynatraceMetadataEnricher.getPropertiesWithIndirection(
             filename, "src/test/resources/metadata_file.properties");
-    List<String> expected = Arrays.asList("key1=value1", "key2=value2", "key3=value3");
+
+    String nonExistentAlternativeFilename = generateNonExistentFilename();
+    Properties expected = new Properties();
+    expected.setProperty("key1", "value1");
+    expected.setProperty("key2", "value2");
+    expected.setProperty("key3", "value3");
+
     assertEquals(expected, result);
   }
 
   @Test
-  public void
-      testGetMetadataFileContentWithRedirection_IndirectionFileReturnsNullAndAlternativeDoesNotExist() {
+  void testGetMetadataFileContentWithRedirection_IndirectionFileReturnsNullAndAlternativeDoesNotExist() {
     try (MockedStatic<DynatraceMetadataEnricher> mockEnricher =
         Mockito.mockStatic(DynatraceMetadataEnricher.class)) {
       mockEnricher
@@ -177,20 +167,19 @@ public class DynatraceMetadataEnricherTest {
       mockEnricher
           .when(
               () ->
-                  DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
+                  DynatraceMetadataEnricher.getPropertiesWithIndirection(
                       Mockito.anyString(), Mockito.anyString()))
           .thenCallRealMethod();
 
-      List<String> result =
-          DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
+      Properties result =
+          DynatraceMetadataEnricher.getPropertiesWithIndirection(
               "src/test/resources/mock_target.properties", nonExistentAlternativeFile);
-      assertEquals(Collections.<String>emptyList(), result);
+      assertEquals(new Properties(), result);
     }
   }
 
   @Test
-  public void
-      testGetMetadataFileContentWithRedirection_IndirectionFileReturnsNullAndAlternativeDoesExist() {
+  void testGetMetadataFileContentWithRedirection_IndirectionFileReturnsNullAndAlternativeDoesExist() {
     try (MockedStatic<DynatraceMetadataEnricher> mockEnricher =
         Mockito.mockStatic(DynatraceMetadataEnricher.class)) {
       mockEnricher
@@ -205,28 +194,25 @@ public class DynatraceMetadataEnricherTest {
       mockEnricher
           .when(
               () ->
-                  DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
+                  DynatraceMetadataEnricher.getPropertiesWithIndirection(
                       Mockito.anyString(), Mockito.anyString()))
           .thenCallRealMethod();
-      mockEnricher
-          .when(
-              () ->
-                  DynatraceMetadataEnricher.getDynatraceMetadataFileContents(
-                      Mockito.any(FileReader.class)))
-          .thenCallRealMethod();
 
-      List<String> result =
-          DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
+      Properties result =
+          DynatraceMetadataEnricher.getPropertiesWithIndirection(
               "src/test/resources/mock_target.properties",
               "src/test/resources/metadata_file.properties");
-      List<String> expected = Arrays.asList("key1=value1", "key2=value2", "key3=value3");
+
+      Properties expected = new Properties();
+      expected.setProperty("key1", "value1");
+      expected.setProperty("key2", "value2");
+      expected.setProperty("key3", "value3");
       assertEquals(expected, result);
     }
   }
 
   @Test
-  public void
-      testGetMetadataFileContentWithRedirection_IndirectionFileReturnsEmptyAndAlternativeDoesNotExist() {
+  void testGetMetadataFileContentWithRedirection_IndirectionFileReturnsEmptyAndAlternativeDoesNotExist() {
     try (MockedStatic<DynatraceMetadataEnricher> mockEnricher =
         Mockito.mockStatic(DynatraceMetadataEnricher.class)) {
       // ignore the return value of the testfile and mock the return value of the
@@ -244,20 +230,19 @@ public class DynatraceMetadataEnricherTest {
       mockEnricher
           .when(
               () ->
-                  DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
+                  DynatraceMetadataEnricher.getPropertiesWithIndirection(
                       Mockito.anyString(), Mockito.anyString()))
           .thenCallRealMethod();
 
-      List<String> result =
-          DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
+      Properties result =
+          DynatraceMetadataEnricher.getPropertiesWithIndirection(
               "src/test/resources/mock_target.properties", nonExistentAlternativeFile);
-      assertEquals(Collections.<String>emptyList(), result);
+      assertEquals(new Properties(), result);
     }
   }
 
   @Test
-  public void
-      testGetMetadataFileContentWithRedirection_IndirectionFileReturnsEmptyAndAlternativeDoesExist() {
+  void testGetMetadataFileContentWithRedirection_IndirectionFileReturnsEmptyAndAlternativeDoesExist() {
     try (MockedStatic<DynatraceMetadataEnricher> mockEnricher =
         Mockito.mockStatic(DynatraceMetadataEnricher.class)) {
       mockEnricher
@@ -272,28 +257,24 @@ public class DynatraceMetadataEnricherTest {
       mockEnricher
           .when(
               () ->
-                  DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
+                  DynatraceMetadataEnricher.getPropertiesWithIndirection(
                       Mockito.anyString(), Mockito.anyString()))
           .thenCallRealMethod();
-      mockEnricher
-          .when(
-              () ->
-                  DynatraceMetadataEnricher.getDynatraceMetadataFileContents(
-                      Mockito.any(FileReader.class)))
-          .thenCallRealMethod();
 
-      List<String> result =
-          DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
+      Properties result =
+          DynatraceMetadataEnricher.getPropertiesWithIndirection(
               "src/test/resources/mock_target.properties",
               "src/test/resources/metadata_file.properties");
-      List<String> expected = Arrays.asList("key1=value1", "key2=value2", "key3=value3");
+      Properties expected = new Properties();
+      expected.setProperty("key1", "value1");
+      expected.setProperty("key2", "value2");
+      expected.setProperty("key3", "value3");
       assertEquals(expected, result);
     }
   }
 
   @Test
-  public void
-      testGetMetadataFileContentWithRedirection_IndirectionFileThrowsAndAlternativeDoesNotExist() {
+  void testGetMetadataFileContentWithRedirection_IndirectionFileThrowsAndAlternativeDoesNotExist() {
     try (MockedStatic<DynatraceMetadataEnricher> mockEnricher =
         Mockito.mockStatic(DynatraceMetadataEnricher.class)) {
       // ignore the return value of the testfile and mock the return value of the
@@ -311,20 +292,19 @@ public class DynatraceMetadataEnricherTest {
       mockEnricher
           .when(
               () ->
-                  DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
+                  DynatraceMetadataEnricher.getPropertiesWithIndirection(
                       Mockito.anyString(), Mockito.anyString()))
           .thenCallRealMethod();
 
-      List<String> result =
-          DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
+      Properties result =
+          DynatraceMetadataEnricher.getPropertiesWithIndirection(
               "src/test/resources/mock_target.properties", nonExistentAlternativeFile);
-      assertEquals(Collections.<String>emptyList(), result);
+      assertEquals(new Properties(), result);
     }
   }
 
   @Test
-  public void
-      testGetMetadataFileContentWithRedirection_IndirectionFileThrowsAndAlternativeDoesExist() {
+  void testGetMetadataFileContentWithRedirection_IndirectionFileThrowsAndAlternativeDoesExist() {
     try (MockedStatic<DynatraceMetadataEnricher> mockEnricher =
         Mockito.mockStatic(DynatraceMetadataEnricher.class)) {
       mockEnricher
@@ -339,27 +319,25 @@ public class DynatraceMetadataEnricherTest {
       mockEnricher
           .when(
               () ->
-                  DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
+                  DynatraceMetadataEnricher.getPropertiesWithIndirection(
                       Mockito.anyString(), Mockito.anyString()))
           .thenCallRealMethod();
-      mockEnricher
-          .when(
-              () ->
-                  DynatraceMetadataEnricher.getDynatraceMetadataFileContents(
-                      Mockito.any(FileReader.class)))
-          .thenCallRealMethod();
 
-      List<String> result =
-          DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
+      Properties result =
+          DynatraceMetadataEnricher.getPropertiesWithIndirection(
               "src/test/resources/mock_target.properties",
               "src/test/resources/metadata_file.properties");
-      List<String> expected = Arrays.asList("key1=value1", "key2=value2", "key3=value3");
+
+      Properties expected = new Properties();
+      expected.setProperty("key1", "value1");
+      expected.setProperty("key2", "value2");
+      expected.setProperty("key3", "value3");
       assertEquals(expected, result);
     }
   }
 
   @Test
-  public void testGetMetadataFileContentWithRedirection_MetadataFileDoesNotExist() {
+  void testGetMetadataFileContentWithRedirection_MetadataFileDoesNotExist() {
     String metadataFilename = generateNonExistentFilename();
     try (MockedStatic<DynatraceMetadataEnricher> mockEnricher =
         Mockito.mockStatic(DynatraceMetadataEnricher.class)) {
@@ -375,30 +353,24 @@ public class DynatraceMetadataEnricherTest {
       mockEnricher
           .when(
               () ->
-                  DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
+                  DynatraceMetadataEnricher.getPropertiesWithIndirection(
                       Mockito.anyString(), Mockito.anyString()))
-          .thenCallRealMethod();
-      mockEnricher
-          .when(
-              () ->
-                  DynatraceMetadataEnricher.getDynatraceMetadataFileContents(
-                      Mockito.any(FileReader.class)))
           .thenCallRealMethod();
 
       // call with an existing indirection target as alternative.
       // if the test failed, the alternative file would be read and results would be returned
       // which in turn would break the test.
-      List<String> result =
-          DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
+      Properties result =
+          DynatraceMetadataEnricher.getPropertiesWithIndirection(
               "src/test/resources/mock_target.properties",
               "src/test/resources/metadata_file.properties");
 
-      assertEquals(Collections.<String>emptyList(), result);
+      assertEquals(new Properties(), result);
     }
   }
 
   @Test
-  public void testGetMetadataFileContentWithRedirection_MetadataFileReadThrows() {
+  void testGetMetadataFileContentWithRedirection_EmptyMetadataFile() {
     try (MockedStatic<DynatraceMetadataEnricher> mockEnricher =
         Mockito.mockStatic(DynatraceMetadataEnricher.class)) {
       mockEnricher
@@ -407,58 +379,22 @@ public class DynatraceMetadataEnricherTest {
       mockEnricher
           .when(
               () ->
-                  DynatraceMetadataEnricher.getDynatraceMetadataFileContents(
-                      Mockito.any(FileReader.class)))
-          .thenThrow(new IOException("test exception"));
-      mockEnricher
-          .when(
-              () ->
-                  DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
+                  DynatraceMetadataEnricher.getPropertiesWithIndirection(
                       Mockito.anyString(), Mockito.anyString()))
           .thenCallRealMethod();
 
       // this should never be used but is required.
       String alternativeFileName = generateNonExistentFilename();
 
-      List<String> result =
-          DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
+      Properties result =
+          DynatraceMetadataEnricher.getPropertiesWithIndirection(
               "src/test/resources/mock_target.properties", alternativeFileName);
-      assertEquals(Collections.<String>emptyList(), result);
+      assertEquals(new Properties(), result);
     }
   }
 
   @Test
-  public void testGetMetadataFileContentWithRedirection_EmptyMetadataFile() {
-    try (MockedStatic<DynatraceMetadataEnricher> mockEnricher =
-        Mockito.mockStatic(DynatraceMetadataEnricher.class)) {
-      mockEnricher
-          .when(() -> DynatraceMetadataEnricher.getMetadataFileName(Mockito.any(FileReader.class)))
-          .thenReturn("src/test/resources/mock_target.properties");
-      mockEnricher
-          .when(
-              () ->
-                  DynatraceMetadataEnricher.getDynatraceMetadataFileContents(
-                      Mockito.any(FileReader.class)))
-          .thenReturn(Collections.emptyList());
-      mockEnricher
-          .when(
-              () ->
-                  DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
-                      Mockito.anyString(), Mockito.anyString()))
-          .thenCallRealMethod();
-
-      // this should never be used but is required.
-      String alternativeFileName = generateNonExistentFilename();
-
-      List<String> result =
-          DynatraceMetadataEnricher.getMetadataFileContentWithRedirection(
-              "src/test/resources/mock_target.properties", alternativeFileName);
-      assertEquals(Collections.<String>emptyList(), result);
-    }
-  }
-
-  @Test
-  public void testFileExistsAndIsReadable() {
+  void testFileExistsAndIsReadable() {
     assertFalse(DynatraceMetadataEnricher.fileExistsAndIsReadable(null));
     assertFalse(DynatraceMetadataEnricher.fileExistsAndIsReadable(""));
     assertFalse(DynatraceMetadataEnricher.fileExistsAndIsReadable(generateNonExistentFilename()));


### PR DESCRIPTION
This PR replaces the custom parsing code for the OneAgent Metadata file with `Properties.load()`