### PR TITLE
Increase line length limit to 50000 characters

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 group 'com.dynatrace.metric.util'
-version = '1.5.0'
+version = '1.6.0'
 
 repositories {
     mavenCentral()

--- a/lib/src/main/java/com/dynatrace/metric/util/Metric.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/Metric.java
@@ -86,7 +86,7 @@ public final class Metric {
      *     counter API will be removed in future versions. Use {@link #setDoubleCounterValueDelta}
      *     instead.
      */
-    @Deprecated(since = "1.2.0")
+    @Deprecated
     public Builder setLongCounterValueTotal(long value) throws MetricException {
       throwIfValueAlreadySet();
       this.value = new MetricValues.LongCounterValue(value, false);
@@ -151,7 +151,7 @@ public final class Metric {
      *     counter API will be removed in future versions. Use {@link #setDoubleCounterValueDelta}
      *     instead.
      */
-    @Deprecated(since = "v1.2.0")
+    @Deprecated
     public Builder setDoubleCounterValueTotal(double value) throws MetricException {
       throwIfValueAlreadySet();
       this.value = new MetricValues.DoubleCounterValue(value, false);

--- a/lib/src/main/java/com/dynatrace/metric/util/Metric.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/Metric.java
@@ -86,7 +86,7 @@ public final class Metric {
      *     counter API will be removed in future versions. Use {@link #setDoubleCounterValueDelta}
      *     instead.
      */
-    @Deprecated
+    @Deprecated(since = "1.2.0")
     public Builder setLongCounterValueTotal(long value) throws MetricException {
       throwIfValueAlreadySet();
       this.value = new MetricValues.LongCounterValue(value, false);
@@ -151,7 +151,7 @@ public final class Metric {
      *     counter API will be removed in future versions. Use {@link #setDoubleCounterValueDelta}
      *     instead.
      */
-    @Deprecated
+    @Deprecated(since = "v1.2.0")
     public Builder setDoubleCounterValueTotal(double value) throws MetricException {
       throwIfValueAlreadySet();
       this.value = new MetricValues.DoubleCounterValue(value, false);
@@ -241,12 +241,13 @@ public final class Metric {
       if (year < 2000 || year > 3000) {
         if (timestampWarningCounter.getAndIncrement() == 0) {
           logger.warning(
-              String.format(
-                  "Order of magnitude of the timestamp seems off (%s). "
-                      + "The timestamp represents a time before the year 2000 or after the year 3000. "
-                      + "Skipping setting timestamp, the current server time will be added upon ingestion. "
-                      + "Only one out of every %d of these messages will be printed.",
-                  timestamp.toString(), TIMESTAMP_WARNING_THROTTLE_FACTOR));
+              () ->
+                  String.format(
+                      "Order of magnitude of the timestamp seems off (%s). "
+                          + "The timestamp represents a time before the year 2000 or after the year 3000. "
+                          + "Skipping setting timestamp, the current server time will be added upon ingestion. "
+                          + "Only one out of every %d of these messages will be printed.",
+                      timestamp, TIMESTAMP_WARNING_THROTTLE_FACTOR));
         }
         timestampWarningCounter.compareAndSet(TIMESTAMP_WARNING_THROTTLE_FACTOR, 0);
 

--- a/lib/src/main/java/com/dynatrace/metric/util/Metric.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/Metric.java
@@ -323,8 +323,8 @@ public final class Metric {
       if (builder.length() > METRIC_LINE_MAX_LENGTH) {
         throw new MetricException(
             String.format(
-                "Serialized line exceeds limit of %d characters accepted by the ingest API:%n%s... (truncated)",
-                METRIC_LINE_MAX_LENGTH, builder.substring(0, 100)));
+                "Serialized line exceeds limit of %d characters accepted by the ingest API. Metric name: '%s'",
+                METRIC_LINE_MAX_LENGTH, normalizedKeyString));
       }
 
       return builder.toString();

--- a/lib/src/main/java/com/dynatrace/metric/util/Metric.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/Metric.java
@@ -30,7 +30,7 @@ public final class Metric {
 
     // The maximum number of characters per serialized line accepted by the ingest API.
     // Lines exceeding this threshold should be dropped.
-    private static final int METRIC_LINE_MAX_LENGTH = 2000;
+    private static final int METRIC_LINE_MAX_LENGTH = 50_000;
 
     // The timestamp warning is rate-limited to log only once every time this factor is reached by
     // the timestampWarningCounter.
@@ -323,7 +323,7 @@ public final class Metric {
         throw new MetricException(
             String.format(
                 "Serialized line exceeds limit of %d characters accepted by the ingest API:%n%s",
-                METRIC_LINE_MAX_LENGTH, builder.toString()));
+                METRIC_LINE_MAX_LENGTH, builder.substring(0, 100) + "... (truncated)"));
       }
 
       return builder.toString();

--- a/lib/src/main/java/com/dynatrace/metric/util/Metric.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/Metric.java
@@ -323,8 +323,8 @@ public final class Metric {
       if (builder.length() > METRIC_LINE_MAX_LENGTH) {
         throw new MetricException(
             String.format(
-                "Serialized line exceeds limit of %d characters accepted by the ingest API:%n%s",
-                METRIC_LINE_MAX_LENGTH, builder.substring(0, 100) + "... (truncated)"));
+                "Serialized line exceeds limit of %d characters accepted by the ingest API:%n%s... (truncated)",
+                METRIC_LINE_MAX_LENGTH, builder.substring(0, 100)));
       }
 
       return builder.toString();

--- a/lib/src/test/java/com/dynatrace/metric/util/MetricBuilderTest.java
+++ b/lib/src/test/java/com/dynatrace/metric/util/MetricBuilderTest.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
-
 import org.junit.jupiter.api.Test;
 
 class MetricBuilderTest {
@@ -30,7 +29,8 @@ class MetricBuilderTest {
   }
 
   @Test
-  public void testSetLongCounterValueTotal() throws MetricException {
+  @Deprecated(since = "v1.2.0")
+  void testSetLongCounterValueTotal() throws MetricException {
     String expected = "name count,1";
     String actual = Metric.builder("name").setLongCounterValueTotal(1).serialize();
 
@@ -38,7 +38,7 @@ class MetricBuilderTest {
   }
 
   @Test
-  public void testSetLongGaugeValue() throws MetricException {
+  void testSetLongGaugeValue() throws MetricException {
     String expected = "name gauge,1";
     String actual = Metric.builder("name").setLongGaugeValue(1).serialize();
 
@@ -46,7 +46,7 @@ class MetricBuilderTest {
   }
 
   @Test
-  public void testSetLongCounterValueDelta() throws MetricException {
+  void testSetLongCounterValueDelta() throws MetricException {
     String expected = "name count,delta=1";
     String actual = Metric.builder("name").setLongCounterValueDelta(1).serialize();
 
@@ -54,7 +54,7 @@ class MetricBuilderTest {
   }
 
   @Test
-  public void testSetLongSummaryValue() throws MetricException {
+  void testSetLongSummaryValue() throws MetricException {
     String expected = "name gauge,min=1,max=10,sum=20,count=7";
     String actual = Metric.builder("name").setLongSummaryValue(1, 10, 20, 7).serialize();
 
@@ -62,7 +62,8 @@ class MetricBuilderTest {
   }
 
   @Test
-  public void testSetDoubleCounterValueTotal() throws MetricException {
+  @Deprecated(since = "v1.2.0")
+  void testSetDoubleCounterValueTotal() throws MetricException {
     String expected = "name count,1.23";
     String actual = Metric.builder("name").setDoubleCounterValueTotal(1.23).serialize();
 
@@ -70,7 +71,7 @@ class MetricBuilderTest {
   }
 
   @Test
-  public void testSetDoubleGauge() throws MetricException {
+  void testSetDoubleGauge() throws MetricException {
     String expected = "name gauge,1.23";
     String actual = Metric.builder("name").setDoubleGaugeValue(1.23).serialize();
 
@@ -78,7 +79,7 @@ class MetricBuilderTest {
   }
 
   @Test
-  public void testSetDoubleCounterValueDelta() throws MetricException {
+  void testSetDoubleCounterValueDelta() throws MetricException {
     String expected = "name count,delta=1.23";
     String actual = Metric.builder("name").setDoubleCounterValueDelta(1.23).serialize();
 
@@ -86,7 +87,7 @@ class MetricBuilderTest {
   }
 
   @Test
-  public void testSetDoubleSummaryValue() throws MetricException {
+  void testSetDoubleSummaryValue() throws MetricException {
     String expected = "name gauge,min=1.23,max=10.34,sum=20.45,count=7";
     String actual = Metric.builder("name").setDoubleSummaryValue(1.23, 10.34, 20.45, 7).serialize();
 
@@ -94,7 +95,7 @@ class MetricBuilderTest {
   }
 
   @Test
-  public void testNoValueSet() {
+  void testNoValueSet() {
     assertThrows(MetricException.class, () -> Metric.builder("name").serialize());
   }
 
@@ -110,52 +111,52 @@ class MetricBuilderTest {
   }
 
   @Test
-  public void testNameContainsInvalidChars() throws MetricException {
-    String expected = "_ count,1";
-    String actual = Metric.builder("~@#$").setLongCounterValueTotal(1).serialize();
+  void testNameContainsInvalidChars() throws MetricException {
+    String expected = "_ count,delta=1";
+    String actual = Metric.builder("~@#$").setLongCounterValueDelta(1).serialize();
     assertEquals(expected, actual);
   }
 
   @Test
-  public void testPrefix() throws MetricException {
-    String expected = "prefix.name count,1";
+  void testPrefix() throws MetricException {
+    String expected = "prefix.name count,delta=1";
     String actual =
-        Metric.builder("name").setPrefix("prefix").setLongCounterValueTotal(1).serialize();
+        Metric.builder("name").setPrefix("prefix").setLongCounterValueDelta(1).serialize();
 
     assertEquals(expected, actual);
   }
 
   @Test
-  public void testPrefixWithTrailingDot() throws MetricException {
-    String expected = "prefix.name count,1";
+  void testPrefixWithTrailingDot() throws MetricException {
+    String expected = "prefix.name count,delta=1";
     String actual =
-        Metric.builder("name").setPrefix("prefix.").setLongCounterValueTotal(1).serialize();
+        Metric.builder("name").setPrefix("prefix.").setLongCounterValueDelta(1).serialize();
 
     assertEquals(expected, actual);
   }
 
   @Test
-  public void testPrefixContainsInvalidChars() throws MetricException {
-    String expected = "_.name count,1";
+  void testPrefixContainsInvalidChars() throws MetricException {
+    String expected = "_.name count,delta=1";
     String actual =
-        Metric.builder("name").setPrefix("~@#$").setLongCounterValueTotal(1).serialize();
+        Metric.builder("name").setPrefix("~@#$").setLongCounterValueDelta(1).serialize();
     assertEquals(expected, actual);
   }
 
   @Test
-  public void testPrefixAndNameContainInvalidChars() throws MetricException {
-    String expected = "_._ count,1";
-    String actual = Metric.builder("~@#$").setPrefix("!@#").setLongCounterValueTotal(1).serialize();
+  void testPrefixAndNameContainInvalidChars() throws MetricException {
+    String expected = "_._ count,delta=1";
+    String actual = Metric.builder("~@#$").setPrefix("!@#").setLongCounterValueDelta(1).serialize();
     assertEquals(expected, actual);
   }
 
   @Test
-  public void testSetTimestamp() throws MetricException {
-    String expected = "prefix.name count,1 1616580000123";
+  void testSetTimestamp() throws MetricException {
+    String expected = "prefix.name count,delta=1 1616580000123";
     String actual =
         Metric.builder("name")
             .setPrefix("prefix")
-            .setLongCounterValueTotal(1)
+            .setLongCounterValueDelta(1)
             .setTimestamp(Instant.ofEpochMilli(1616580000123L))
             .serialize();
 
@@ -163,13 +164,13 @@ class MetricBuilderTest {
   }
 
   @Test
-  public void testSetInvalidTimestampsSeconds() throws MetricException {
+  void testSetInvalidTimestampsSeconds() throws MetricException {
     // timestamp specified in seconds
-    String expected = "prefix.name count,1";
+    String expected = "prefix.name count,delta=1";
     String actual =
         Metric.builder("name")
             .setPrefix("prefix")
-            .setLongCounterValueTotal(1)
+            .setLongCounterValueDelta(1)
             .setTimestamp(Instant.ofEpochMilli(1616580000L))
             .serialize();
 
@@ -177,13 +178,13 @@ class MetricBuilderTest {
   }
 
   @Test
-  public void testSetInvalidTimestampsNanoseconds() throws MetricException {
+  void testSetInvalidTimestampsNanoseconds() throws MetricException {
     // timestamp specified in nanoseconds
-    String expected = "prefix.name count,1";
+    String expected = "prefix.name count,delta=1";
     String actual =
         Metric.builder("name")
             .setPrefix("prefix")
-            .setLongCounterValueTotal(1)
+            .setLongCounterValueDelta(1)
             .setTimestamp(Instant.ofEpochMilli(1616580000000000L))
             .serialize();
 
@@ -191,14 +192,14 @@ class MetricBuilderTest {
   }
 
   @Test
-  public void testCurrentTimestamp() throws MetricException {
-    String expectedStart = "prefix.name count,1 ";
+  void testCurrentTimestamp() throws MetricException {
+    String expectedStart = "prefix.name count,delta=1 ";
     // this is just for the string length.
-    String expectedDummy = "prefix.name count,1 1616580000000";
+    String expectedDummy = "prefix.name count,delta=1 1616580000000";
     String actual =
         Metric.builder("name")
             .setPrefix("prefix")
-            .setLongCounterValueTotal(1)
+            .setLongCounterValueDelta(1)
             .setCurrentTime()
             .serialize();
 
@@ -207,12 +208,12 @@ class MetricBuilderTest {
   }
 
   @Test
-  public void testSetDimensions() throws MetricException {
-    String expected = "prefix.name,dim1=val1 count,1";
+  void testSetDimensions() throws MetricException {
+    String expected = "prefix.name,dim1=val1 count,delta=1";
     String actual =
         Metric.builder("name")
             .setPrefix("prefix")
-            .setLongCounterValueTotal(1)
+            .setLongCounterValueDelta(1)
             .setDimensions(DimensionList.create(Dimension.create("dim1", "val1")))
             .serialize();
 
@@ -220,12 +221,12 @@ class MetricBuilderTest {
   }
 
   @Test
-  public void testJustDefaultDimensions() throws MetricException {
-    String expected = "prefix.name,defdim1=val1 count,1";
+  void testJustDefaultDimensions() throws MetricException {
+    String expected = "prefix.name,defdim1=val1 count,delta=1";
     String actual =
         Metric.builder("name")
             .setPrefix("prefix")
-            .setLongCounterValueTotal(1)
+            .setLongCounterValueDelta(1)
             .setDefaultDimensions(DimensionList.create(Dimension.create("defdim1", "val1")))
             .serialize();
 
@@ -233,13 +234,13 @@ class MetricBuilderTest {
   }
 
   @Test
-  public void testSetDefaultAndDynamicDimensions() throws MetricException {
-    String expectedBase = "prefix.name count,1";
+  void testSetDefaultAndDynamicDimensions() throws MetricException {
+    String expectedBase = "prefix.name count,delta=1";
     List<String> expectedDims = Arrays.asList("defaultdim1=defaultVal1", "dim1=val1");
     String actual =
         Metric.builder("name")
             .setPrefix("prefix")
-            .setLongCounterValueTotal(1)
+            .setLongCounterValueDelta(1)
             // only available in package.
             .setDimensions(DimensionList.create(Dimension.create("dim1", "val1")))
             .setDefaultDimensions(
@@ -253,14 +254,14 @@ class MetricBuilderTest {
   }
 
   @Test
-  public void testSetDefaultAndDynamicAndMetadataDimensions() throws MetricException {
-    String expectedBase = "prefix.name count,1";
+  void testSetDefaultAndDynamicAndMetadataDimensions() throws MetricException {
+    String expectedBase = "prefix.name count,delta=1";
     List<String> expectedDims =
         Arrays.asList("defaultdim1=defaultVal1", "dim1=val1", "metadatadim1=metadataVal1");
     String actual =
         Metric.builder("name")
             .setPrefix("prefix")
-            .setLongCounterValueTotal(1)
+            .setLongCounterValueDelta(1)
             .setDimensions(DimensionList.create(Dimension.create("dim1", "val1")))
             .setDefaultDimensions(
                 DimensionList.create(Dimension.create("defaultDim1", "defaultVal1")))
@@ -276,14 +277,14 @@ class MetricBuilderTest {
   }
 
   @Test
-  public void testOverwriting() throws MetricException {
-    String expectedBase = "prefix.name count,1";
+  void testOverwriting() throws MetricException {
+    String expectedBase = "prefix.name count,delta=1";
     List<String> expectedDims =
         Arrays.asList("dim1=defaultVal1", "dim2=dynamicVal2", "dim3=metadataVal3");
     String actual =
         Metric.builder("name")
             .setPrefix("prefix")
-            .setLongCounterValueTotal(1)
+            .setLongCounterValueDelta(1)
             .setDefaultDimensions(
                 DimensionList.create(
                     Dimension.create("dim1", "defaultVal1"),

--- a/lib/src/test/java/com/dynatrace/metric/util/MetricBuilderTest.java
+++ b/lib/src/test/java/com/dynatrace/metric/util/MetricBuilderTest.java
@@ -19,8 +19,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
 class MetricBuilderTest {
@@ -322,24 +320,8 @@ class MetricBuilderTest {
 
     MetricException me = assertThrows(MetricException.class, metricBuilder::serialize);
 
-    Pattern messagePattern =
-        Pattern.compile(
-            "Serialized line exceeds limit of 50000 characters accepted by the ingest API:\\r?\\nprefix.name,dim\\d+=val\\d+");
-    Matcher matcher = messagePattern.matcher(me.getMessage());
-    assertTrue(matcher.find());
-    // assert that the string starts with the match
-    assertEquals(0, matcher.start());
-
-    // The message is truncated (to not print 50.000 characters) and the dimensions are in a random
-    // order (due to the deduplication, which uses a map that does not preserve order). Therefore,
-    // we can just assert that there are some dimensions before the truncation, but not which ones.
-    Pattern dimensionPattern = Pattern.compile("dim\\d+=val\\d+,");
-    long foundDimensionMatches = dimensionPattern.matcher(me.getMessage()).results().count();
-    // assert that there are multiple dimensions
-    assertTrue(foundDimensionMatches > 3);
-
-    assertTrue(me.getMessage().endsWith("... (truncated)"));
-    // assert that the line has been truncated.
-    assertTrue(me.getMessage().length() < 200);
+    assertEquals(
+        "Serialized line exceeds limit of 50000 characters accepted by the ingest API. Metric name: 'prefix.name'",
+        me.getMessage());
   }
 }

--- a/lib/src/test/java/com/dynatrace/metric/util/MetricBuilderTest.java
+++ b/lib/src/test/java/com/dynatrace/metric/util/MetricBuilderTest.java
@@ -100,14 +100,13 @@ class MetricBuilderTest {
   }
 
   @Test
-  public void testValueSetTwice() {
-    assertThrows(
-        MetricException.class,
-        () ->
-            Metric.builder("name")
-                .setLongCounterValueTotal(1)
-                .setDoubleCounterValueTotal(1.23)
-                .serialize());
+  void testValueSetTwice() {
+    // first setting of value does not throw.
+    Metric.Builder builder =
+        assertDoesNotThrow(() -> Metric.builder("name").setLongCounterValueDelta(1));
+
+    // trying to set again throws an exception.
+    assertThrows(MetricException.class, () -> builder.setDoubleCounterValueDelta(1.23));
   }
 
   @Test

--- a/lib/src/test/java/com/dynatrace/metric/util/MetricBuilderTest.java
+++ b/lib/src/test/java/com/dynatrace/metric/util/MetricBuilderTest.java
@@ -332,5 +332,7 @@ class MetricBuilderTest {
     assertTrue(dimensionPattern.matcher(me.getMessage()).find());
 
     assertTrue(me.getMessage().endsWith("... (truncated)"));
+    // assert that the line has been truncated.
+    assertTrue(me.getMessage().length() < 200);
   }
 }

--- a/lib/src/test/java/com/dynatrace/metric/util/MetricBuilderTest.java
+++ b/lib/src/test/java/com/dynatrace/metric/util/MetricBuilderTest.java
@@ -29,7 +29,7 @@ class MetricBuilderTest {
   }
 
   @Test
-  @Deprecated(since = "v1.2.0")
+  @Deprecated
   void testSetLongCounterValueTotal() throws MetricException {
     String expected = "name count,1";
     String actual = Metric.builder("name").setLongCounterValueTotal(1).serialize();
@@ -62,7 +62,7 @@ class MetricBuilderTest {
   }
 
   @Test
-  @Deprecated(since = "v1.2.0")
+  @Deprecated
   void testSetDoubleCounterValueTotal() throws MetricException {
     String expected = "name count,1.23";
     String actual = Metric.builder("name").setDoubleCounterValueTotal(1.23).serialize();


### PR DESCRIPTION
The actual change is in the first commit (4d86d19217965d1e6271616e09d36501175b3a8f), the other commits are updating the tests to not use deprecated APIs (where not necessary). I also decided to truncate the line that is logged if it exceeds the 50k character limit, since logging a > 50k character message seems less than ideal to me.