### PR TITLE
Add additional output to for identifying dropped dimensions 

### DIFF
--- a/lib/src/main/java/com/dynatrace/metric/util/DimensionList.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/DimensionList.java
@@ -140,7 +140,7 @@ public final class DimensionList {
     boolean firstIteration = true;
 
     for (Dimension dimension : dimensions) {
-      // if the dimension is not valid, don't add it to the
+      // if the dimension is not valid, don't add it to the serialized line
       if (isDimensionValid(dimension)) {
         if (!firstIteration) {
           builder.append(",");

--- a/lib/src/main/java/com/dynatrace/metric/util/DimensionList.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/DimensionList.java
@@ -140,15 +140,34 @@ public final class DimensionList {
     boolean firstIteration = true;
 
     for (Dimension dimension : dimensions) {
-      if (!firstIteration) {
-        builder.append(",");
-      } else {
-        firstIteration = false;
-      }
+      // if the dimension is not valid, don't add it to the
+      if (isDimensionValid(dimension)) {
+        if (!firstIteration) {
+          builder.append(",");
+        } else {
+          firstIteration = false;
+        }
 
-      builder.append(dimension.serialize());
+        builder.append(dimension.serialize());
+      }
     }
 
     return builder.toString();
+  }
+
+  static boolean isDimensionValid(Dimension dimension) {
+    String key = dimension.getKey();
+    if (key == null || key.isEmpty()) {
+      logger.warning("dimension key is null or empty.");
+      return false;
+    }
+
+    String value = dimension.getValue();
+    if (value == null || value.isEmpty()) {
+      logger.warning(() -> String.format("dimension value for dimension key '%s' is null or empty.", key));
+      return false;
+    }
+
+    return true;
   }
 }

--- a/lib/src/main/java/com/dynatrace/metric/util/DimensionList.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/DimensionList.java
@@ -156,6 +156,9 @@ public final class DimensionList {
   }
 
   static boolean isDimensionValid(Dimension dimension) {
+    // Dimension key should never be empty, as the creation of a dimension list will drop all dimension with empty
+    // keys. DimensionLists will always be normalized upon creation. At the point where this method is used, all
+    // dimensions should be part of a dimension list, and therefore never contain null or empty dimension keys.
     String key = dimension.getKey();
     if (key == null || key.isEmpty()) {
       logger.warning("dimension key is null or empty.");

--- a/lib/src/main/java/com/dynatrace/metric/util/Metric.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/Metric.java
@@ -45,6 +45,7 @@ public final class Metric {
     private DimensionList dynatraceMetadataDimensions;
 
     private Builder(String metricKey) {
+      logger.fine(() -> String.format("building metric '%s'", metricKey));
       this.metricKey = metricKey;
     }
 
@@ -286,7 +287,6 @@ public final class Metric {
         throw new MetricException("Normalized metric key is empty.");
       }
 
-      logger.fine(() -> String.format("serializing metric '%s'", normalizedKeyString));
 
       if (this.value == null) {
         throw new MetricException("No value set for metric.");
@@ -329,6 +329,7 @@ public final class Metric {
                 METRIC_LINE_MAX_LENGTH, normalizedKeyString));
       }
 
+      logger.fine(() -> String.format("finished serializing metric '%s' (final name: '%s')", metricKey, normalizedKeyString));
       return builder.toString();
     }
 

--- a/lib/src/main/java/com/dynatrace/metric/util/Metric.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/Metric.java
@@ -286,6 +286,8 @@ public final class Metric {
         throw new MetricException("Normalized metric key is empty.");
       }
 
+      logger.fine(() -> String.format("serializing metric '%s'", normalizedKeyString));
+
       if (this.value == null) {
         throw new MetricException("No value set for metric.");
       }

--- a/lib/src/main/java/com/dynatrace/metric/util/Metric.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/Metric.java
@@ -287,7 +287,6 @@ public final class Metric {
         throw new MetricException("Normalized metric key is empty.");
       }
 
-
       if (this.value == null) {
         throw new MetricException("No value set for metric.");
       }

--- a/lib/src/test/java/com/dynatrace/metric/util/MetricBuilderTest.java
+++ b/lib/src/test/java/com/dynatrace/metric/util/MetricBuilderTest.java
@@ -219,6 +219,30 @@ class MetricBuilderTest {
   }
 
   @Test
+  void testSetNullOrEmptyDimensions() throws MetricException {
+    String expected = "prefix.name,dim1=val1 count,delta=1";
+    String actual =
+      Metric.builder("name")
+        .setPrefix("prefix")
+        .setLongCounterValueDelta(1)
+        .setDimensions(
+          DimensionList.create(
+            Dimension.create("dim1", "val1"),
+            Dimension.create("dim2", null),
+            Dimension.create("dim3", ""),
+            Dimension.create("", "val4"),
+            Dimension.create(null, "val5"),
+            Dimension.create("", null),
+            Dimension.create(null, ""),
+            Dimension.create("", ""),
+            Dimension.create(null, null)
+          )
+        ).serialize();
+    assertEquals(expected, actual);
+
+  }
+
+  @Test
   void testJustDefaultDimensions() throws MetricException {
     String expected = "prefix.name,defdim1=val1 count,delta=1";
     String actual =

--- a/lib/src/test/java/com/dynatrace/metric/util/MetricBuilderTest.java
+++ b/lib/src/test/java/com/dynatrace/metric/util/MetricBuilderTest.java
@@ -239,7 +239,6 @@ class MetricBuilderTest {
           )
         ).serialize();
     assertEquals(expected, actual);
-
   }
 
   @Test


### PR DESCRIPTION
Will now debug log the name of the metric before normalizing, and the name of the dimension being dropped if the value is null or empty.