### PR TITLE
Check for inconsistent gauge fields for summaries

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 group 'com.dynatrace.metric.util'
-version = '2.0.1'
+version = '2.0.2'
 
 repositories {
     mavenCentral()

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 group 'com.dynatrace.metric.util'
-version = '2.0.2'
+version = '2.1.0'
 
 repositories {
     mavenCentral()

--- a/lib/src/main/java/com/dynatrace/metric/util/MetricLineConstants.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/MetricLineConstants.java
@@ -73,6 +73,8 @@ final class MetricLineConstants {
     static final String GAUGE_NAN_MESSAGE = "NaN values: min: %f, max %f, sum: %f, count: %d";
     static final String GAUGE_MIN_GREATER_MAX_MESSAGE =
         "max < min: min: %f, max: %f, sum: %f, count: %d";
+    static final String GAUGE_INCONSISTENT_FIELDS_MESSAGE =
+        "inconsistent gauge fields: min <= avg <= max doesn't hold: min: %f, max: %f, sum: %f, count: %d, avg: %f, tolerance: %f";
 
     static final String VALUE_NAN_MESSAGE = "Metric value was NaN";
     static final String VALUE_INFINITE_MESSAGE = "Metric value was infinite (%f)";

--- a/lib/src/main/java/com/dynatrace/metric/util/NumberValueValidator.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/NumberValueValidator.java
@@ -17,6 +17,7 @@ import com.dynatrace.metric.util.MetricLineConstants.ValidationMessages;
 
 /** Offers validation methods for metric-line values */
 final class NumberValueValidator {
+  private static final double COMPARISON_ABSOLUTE_TOLERANCE = 0.000001D;
 
   private NumberValueValidator() {}
 
@@ -59,7 +60,47 @@ final class NumberValueValidator {
               String.format(
                   ValidationMessages.GAUGE_MIN_GREATER_MAX_MESSAGE, min, max, sum, count));
     }
+
+    double avg = sum / count;
+    if (!(lessOrEqualWithAbsoluteTolerance(min, avg)
+        && lessOrEqualWithAbsoluteTolerance(avg, max))) {
+      // in this case the min <= avg <= max does not hold
+      return BooleanResultMessage.newInvalid(
+          () ->
+              String.format(
+                  ValidationMessages.GAUGE_INCONSISTENT_FIELDS_MESSAGE,
+                  min,
+                  max,
+                  sum,
+                  count,
+                  avg,
+                  COMPARISON_ABSOLUTE_TOLERANCE));
+    }
+
     return BooleanResultMessage.newValid();
+  }
+
+  private static boolean lessOrEqualWithAbsoluteTolerance(double val1, double val2) {
+    // equals
+    if (Double.valueOf(val1).equals(Double.valueOf(val2))) {
+      return true;
+    }
+
+    // not equal, two cases:
+    // val1 < val2: should always evaluate to true
+    // val1 slightly < val2 -> val1 - val2 == negative     | result <= tolerance -> true
+    // val1 much < val2 -> val1 - val2 == negative         | result <= tolerance -> true
+    //
+    // val2 > val2: should only evaluate to true if
+    // - val1 is smaller than val2, or if
+    // - val1 is bigger than val2 but within the tolerance
+    // val1 slightly > val2 -> val1 - val2 == small number | result <= tolerance -> true
+    // val1 much > val2 -> val1 - val2 == larger number    | result > tolerance -> false
+    if ((val1 - val2) <= COMPARISON_ABSOLUTE_TOLERANCE) {
+      return true;
+    }
+
+    return false;
   }
 
   /**

--- a/lib/src/main/java/com/dynatrace/metric/util/NumberValueValidator.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/NumberValueValidator.java
@@ -91,9 +91,8 @@ final class NumberValueValidator {
     // val1 slightly < val2 -> val1 - val2 == negative     | result <= tolerance -> true
     // val1 much < val2 -> val1 - val2 == negative         | result <= tolerance -> true
     //
-    // val2 > val2: should only evaluate to true if
-    // - val1 is smaller than val2, or if
-    // - val1 is bigger than val2 but within the tolerance
+    // val1 > val2: should only evaluate to true if
+    // - val1 is bigger than val2 but within the tolerance:
     // val1 slightly > val2 -> val1 - val2 == small number | result <= tolerance -> true
     // val1 much > val2 -> val1 - val2 == larger number    | result > tolerance -> false
     if ((val1 - val2) <= COMPARISON_ABSOLUTE_TOLERANCE) {

--- a/lib/src/test/java/com/dynatrace/metric/util/NumberValueValidatorTest.java
+++ b/lib/src/test/java/com/dynatrace/metric/util/NumberValueValidatorTest.java
@@ -32,10 +32,32 @@ public class NumberValueValidatorTest {
   }
 
   @Test
+  void testInconsistentGaugeFields() {
+    // min > avg
+    assertFalse(NumberValueValidator.isSummaryValid(2.5, 3, 6, 3).isValid());
+    assertFalse(NumberValueValidator.isSummaryValid(5, 3, 3, 1).isValid());
+    assertFalse(NumberValueValidator.isSummaryValid(-2, -2, -5, 2).isValid());
+
+    // max < avg
+    assertFalse(NumberValueValidator.isSummaryValid(2, 2, 5, 3).isValid());
+    assertFalse(NumberValueValidator.isSummaryValid(10.5, 10.6, 21.3, 1).isValid());
+    assertFalse(NumberValueValidator.isSummaryValid(-5.3, -4.1, -5, 2).isValid());
+
+    // test tolerances (tolerance == 0.000001);
+    // avg == 2; min <= avg does not hold (but is within tolerance).
+    assertTrue(NumberValueValidator.isSummaryValid(2.0000001, 3, 4, 2).isValid());
+    // avg == -2; min <= avg does not hold (but is within tolerance)
+    assertTrue(NumberValueValidator.isSummaryValid(-1.999999, -1, -4, 2).isValid());
+
+    // avg == 2; max >= avg does not hold (but is within tolerance)
+    assertTrue(NumberValueValidator.isSummaryValid(1.5, 1.999999, 4, 2).isValid());
+    // avg == -2; max >= avg does not hold (but is within tolerance)
+    assertTrue(NumberValueValidator.isSummaryValid(-2.5, -2.0000001, -4, 2).isValid());
+  }
+
+  @Test
   void testSummaryValidator() {
-    assertTrue(() -> NumberValueValidator.isSummaryValid(10.5, 10.6, 21.3, 1).isValid());
     assertTrue(() -> NumberValueValidator.isSummaryValid(-1.3, 4.1, 5, 2).isValid());
-    assertTrue(() -> NumberValueValidator.isSummaryValid(-5.3, -4.1, -5, 2).isValid());
 
     assertTrue(NumberValueValidator.isSummaryValid(0, 0, 0, 0).isValid());
     assertFalse(NumberValueValidator.isSummaryValid(0, 0, 0, -1).isValid());


### PR DESCRIPTION
Metric lines that contain inconsistent gauge fields (i.e., where the min is larger than the average or where the average is larger than the maximum) will be rejected by the Dynatrace API. In order to save network bandwidth, and to get immediate information about which metrics are invalid, this change drops the metric lines on the client side now. Note that this does not change the data that is stored in Dynatrace, just the place where the inconsistent data is dropped (client side vs. API).  