### PR TITLE
Allow curly braces in units

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 group 'com.dynatrace.metric.util'
-version = '2.1.0'
+version = '2.2.0'
 
 repositories {
     mavenCentral()

--- a/lib/src/main/java/com/dynatrace/metric/util/CodePoints.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/CodePoints.java
@@ -37,7 +37,9 @@ final class CodePoints {
 
   static final int PERCENT_SIGN = "%".codePointAt(0);
   static final int OPEN_SQUARE_BRACKET = "[".codePointAt(0);
-  static final int CLOSE_SQUARE_BRACKET = "]".codePointAt(0);
+  static final int CLOSED_SQUARE_BRACKET = "]".codePointAt(0);
+  static final int OPEN_CURLY_BRACKET = "{".codePointAt(0);
+  static final int CLOSED_CURLY_BRACKET = "}".codePointAt(0);
   static final int FORWARD_SLASH = "/".codePointAt(0);
 
   static final int UC_SUPPLEMENTAL_SYMBOLS_AND_PICTOGRAPHS_START = 0x1F900;

--- a/lib/src/main/java/com/dynatrace/metric/util/UnitValidator.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/UnitValidator.java
@@ -51,12 +51,14 @@ final class UnitValidator {
    * @return True if the codepoint is an allowed char, otherwise false.
    */
   private static boolean isAllowedChar(int codePoint) {
-    // Uppercase and lowercase letters, numbers and characters '%','[',']','/' and '_'
+    // Uppercase and lowercase letters, numbers and these special characters (not the comma): %, [, ], {, }, /, _
     return isLetter(codePoint)
         || isNumber(codePoint)
         || codePoint == CodePoints.PERCENT_SIGN
         || codePoint == CodePoints.OPEN_SQUARE_BRACKET
-        || codePoint == CodePoints.CLOSE_SQUARE_BRACKET
+        || codePoint == CodePoints.CLOSED_SQUARE_BRACKET
+        || codePoint == CodePoints.OPEN_CURLY_BRACKET
+        || codePoint == CodePoints.CLOSED_CURLY_BRACKET
         || codePoint == CodePoints.FORWARD_SLASH
         || codePoint == CodePoints.UNDERSCORE;
   }

--- a/lib/src/main/java/com/dynatrace/metric/util/UnitValidator.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/UnitValidator.java
@@ -51,7 +51,8 @@ final class UnitValidator {
    * @return True if the codepoint is an allowed char, otherwise false.
    */
   private static boolean isAllowedChar(int codePoint) {
-    // Uppercase and lowercase letters, numbers and these special characters (not the comma): %, [, ], {, }, /, _
+    // Uppercase and lowercase letters, numbers and these special characters (not the comma): %, [,
+    // ], {, }, /, _
     return isLetter(codePoint)
         || isNumber(codePoint)
         || codePoint == CodePoints.PERCENT_SIGN

--- a/lib/src/test/java/com/dynatrace/metric/util/UnitValidatorTest.java
+++ b/lib/src/test/java/com/dynatrace/metric/util/UnitValidatorTest.java
@@ -77,7 +77,11 @@ class UnitValidatorTest {
             Arguments.of("valid percent sign", "%"),
             Arguments.of("valid forward slash", "/"),
             Arguments.of("valid underscore", "_"),
-            Arguments.of("valid all combined", "[ab09YZ%/_]"));
+            Arguments.of("valid all combined", "{[ab09YZ%/_]}"),
+            Arguments.of("valid open curly bracket", "{"),
+            Arguments.of("valid closed curly bracket", "}"),
+            Arguments.of("valid text enclosed in curly brackets", "{unit}")
+        );
 
     return Stream.concat(
         lowercaseLetters, Stream.concat(uppercaseLetters, Stream.concat(digits, specialCases)));
@@ -89,9 +93,6 @@ class UnitValidatorTest {
         Arguments.of("invalid NUL char", TestUtils.codePointToString(0)),
         Arguments.of("invalid Dollar sign", "$"),
         Arguments.of("invalid Euro sign", "\u20AC"),
-        Arguments.of("invalid open curly bracket", "{"),
-        Arguments.of("invalid closed curly bracket", "}"),
-        Arguments.of("invalid text enclosed in curly brackets", "{unit}"),
         // these are all characters that might occur in the metric line itself but not in the unit
         // string.
         Arguments.of("invalid space", " "),

--- a/lib/src/test/java/com/dynatrace/metric/util/UnitValidatorTest.java
+++ b/lib/src/test/java/com/dynatrace/metric/util/UnitValidatorTest.java
@@ -80,8 +80,7 @@ class UnitValidatorTest {
             Arguments.of("valid all combined", "{[ab09YZ%/_]}"),
             Arguments.of("valid open curly bracket", "{"),
             Arguments.of("valid closed curly bracket", "}"),
-            Arguments.of("valid text enclosed in curly brackets", "{unit}")
-        );
+            Arguments.of("valid text enclosed in curly brackets", "{unit}"));
 
     return Stream.concat(
         lowercaseLetters, Stream.concat(uppercaseLetters, Stream.concat(digits, specialCases)));


### PR DESCRIPTION
The Dynatrace Unit API now allows curly braces. This makes sure that units with curly braces are no longer rejected. 