### PR TITLE
fix(file.util): avoid inotify problems in containers by using polling over FileWatcher

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 group 'com.dynatrace.metric.util'
-version = '2.2.0'
+version = '2.2.1'
 
 repositories {
     mavenCentral()

--- a/lib/src/main/java/com/dynatrace/file/util/DynatraceFileBasedConfigurationProvider.java
+++ b/lib/src/main/java/com/dynatrace/file/util/DynatraceFileBasedConfigurationProvider.java
@@ -56,13 +56,15 @@ public class DynatraceFileBasedConfigurationProvider {
       if (!Files.exists(Paths.get(fileName))) {
         logger.info("File based configuration does not exist, serving default config.");
       } else {
-        poller = FilePollerFactory.getDefault(fileName, pollInterval);
+        poller =
+            FilePollerFactory.getPollBased(
+                fileName, pollInterval != null ? pollInterval : Duration.ofSeconds(60));
       }
     } catch (InvalidPathException e) {
       // This happens on Windows, when the *nix filepath is not valid.
       logger.info(
           () -> String.format("%s is not a valid file path (%s).", fileName, e.getMessage()));
-    } catch (IOException | IllegalArgumentException e) {
+    } catch (IllegalArgumentException e) {
       logger.warning(
           () -> String.format("File polling could not be initialized: %s", e.getMessage()));
     }

--- a/lib/src/main/java/com/dynatrace/file/util/FilePollerFactory.java
+++ b/lib/src/main/java/com/dynatrace/file/util/FilePollerFactory.java
@@ -27,19 +27,18 @@ class FilePollerFactory {
   private FilePollerFactory() {}
 
   /**
-   * Creates the default {@link FilePoller} based on the current OS.
+   * Creates the default {@link FilePoller}.
    *
-   * @implNote On Linux and Windows, * the poll mechanism is based on the {@link
-   *     java.nio.file.WatchService WatchService}. For macOS, * where there is no native
-   *     implementation for the {@link java.nio.file.WatchService WatchService} * bindings, this
-   *     method provides a {@link PollBasedFilePoller}, which polls the file of interest *
-   *     periodically (according to the {@code pollInterval}).
+   * @implNote This method may choose to use a {@link java.nio.file.WatchService}-based implementation
+   * which can be problematic when used in conjunction with container bind-mounts. If the resulting {@link FilePoller}
+   * will be used in such a manner, consider using {@link FilePollerFactory#getPollBased(String, Duration)}.
+   *
    * @param fileName The name of the file to be watched.
-   * @param pollInterval The interval in which the {@link PollBasedFilePoller} polls for changes.
-   *     Only applicable on macOS. Will default to 60s if {@code null} is passed.
+   * @param pollInterval The interval in which the {@link FilePoller} will update, if applicable. Interval MAY not apply
+   *                     to {@link java.nio.file.WatchService} based implementations.
+   *                     Will default to 60s if {@code null} is passed.
    * @return An object that implements the abstract methods on {@link FilePoller}.
-   * @throws IOException if the initialization of the {@link WatchServiceBasedFilePoller} is not
-   *     successful.
+   * @throws IOException if the initialization of the {@link FilePoller} is not successful
    */
   static FilePoller getDefault(String fileName, Duration pollInterval) throws IOException {
     if (IS_MAC_OS) {

--- a/lib/src/main/java/com/dynatrace/file/util/FilePollerFactory.java
+++ b/lib/src/main/java/com/dynatrace/file/util/FilePollerFactory.java
@@ -29,14 +29,14 @@ class FilePollerFactory {
   /**
    * Creates the default {@link FilePoller}.
    *
-   * @implNote This method may choose to use a {@link java.nio.file.WatchService}-based implementation
-   * which can be problematic when used in conjunction with container bind-mounts. If the resulting {@link FilePoller}
-   * will be used in such a manner, consider using {@link FilePollerFactory#getPollBased(String, Duration)}.
-   *
+   * @implNote This method may choose to use a {@link java.nio.file.WatchService}-based
+   *     implementation which can be problematic when used in conjunction with container
+   *     bind-mounts. If the resulting {@link FilePoller} will be used in such a manner, consider
+   *     using {@link FilePollerFactory#getPollBased(String, Duration)}.
    * @param fileName The name of the file to be watched.
-   * @param pollInterval The interval in which the {@link FilePoller} will update, if applicable. Interval MAY not apply
-   *                     to {@link java.nio.file.WatchService} based implementations.
-   *                     Will default to 60s if {@code null} is passed.
+   * @param pollInterval The interval in which the {@link FilePoller} will update, if applicable.
+   *     Interval MAY not apply to {@link java.nio.file.WatchService} based implementations. Will
+   *     default to 60s if {@code null} is passed.
    * @return An object that implements the abstract methods on {@link FilePoller}.
    * @throws IOException if the initialization of the {@link FilePoller} is not successful
    */

--- a/lib/src/main/java/com/dynatrace/file/util/FilePollerFactory.java
+++ b/lib/src/main/java/com/dynatrace/file/util/FilePollerFactory.java
@@ -32,7 +32,7 @@ class FilePollerFactory {
    * @implNote This method may choose to use a {@link java.nio.file.WatchService}-based
    *     implementation which can be problematic when used in conjunction with container
    *     bind-mounts. If the resulting {@link FilePoller} will be used in such a manner, consider
-   *     using {@link FilePollerFactory#getPollBased(String, Duration)}.
+   *     using {@link FilePollerFactory#getPollBased(String, Duration)} instead.
    * @param fileName The name of the file to be watched.
    * @param pollInterval The interval in which the {@link FilePoller} will update, if applicable.
    *     Interval MAY not apply to {@link java.nio.file.WatchService} based implementations. Will


### PR DESCRIPTION
## Description

When using bind-mounts in containers the FileWatcher may not pick up changes to the file, causing the watch-service-based implementation to miss updates to the file. This becomes problematic on token rotations.

This PR switches the implementation to use the `PollBasedFilePoller` (60 second interval) instead. 

**Tests:**
- [x] existing unit tests
- [x] tested manually with a reproducer provided by @pirgeo 

**Additional Resources**
- https://ahmet.im/blog/kubernetes-inotify/
- https://blog.arkey.fr/2019/09/13/watchservice-and-bind-mount/