### PR TITLE
Swap MD5 hash to CRC32 for checksum calculation

### DIFF
--- a/lib/src/main/java/com/dynatrace/file/util/PollBasedFilePoller.java
+++ b/lib/src/main/java/com/dynatrace/file/util/PollBasedFilePoller.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.Objects;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;

--- a/lib/src/main/java/com/dynatrace/file/util/PollBasedFilePoller.java
+++ b/lib/src/main/java/com/dynatrace/file/util/PollBasedFilePoller.java
@@ -73,7 +73,7 @@ class PollBasedFilePoller extends FilePoller {
     // | !null  | null     | update (no file before) |
     // | !null  | !null    | update if changed       |
     if (latestChecksumValue != null) {
-      if (!prevChecksumValue.equals(latestChecksumValue)) {
+      if (!latestChecksumValue.equals(prevChecksumValue)) {
         changedSinceLastInquiry.set(true);
       }
       prevChecksumValue = latestChecksumValue;

--- a/lib/src/test/java/com/dynatrace/file/util/FilePollerTestHelpers.java
+++ b/lib/src/test/java/com/dynatrace/file/util/FilePollerTestHelpers.java
@@ -75,8 +75,10 @@ class FilePollerTestHelpers {
 
     // create the file again
     Files.createFile(path);
-    await().atMost(1, TimeUnit.SECONDS).until(poller::fileContentsUpdated);
+    // creating an empty file does not trigger an update (no new information to be read)
+    await().atMost(1, TimeUnit.SECONDS).until(() -> !poller.fileContentsUpdated());
 
+    // adding new content to the new file will trigger an update.
     Files.write(path, "Some content".getBytes());
     await().atMost(1, TimeUnit.SECONDS).until(poller::fileContentsUpdated);
   }


### PR DESCRIPTION
For this use-case, use of a cryptographic hash function is not required. File contents are being hashed and compared to identify whether a change in the file occurred. 