### PR TITLE
Update Sonatype URL to new portal for Maven Central publishing

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -89,7 +89,7 @@ publishing {
     repositories {
         maven {
             name 'sonatype'
-            url 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+            url 'https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/'
             credentials {
                 username findProperty('sonatypeUsername')
                 password findProperty('sonatypePassword')


### PR DESCRIPTION
As per https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration.