### PR TITLE
Increase metric key and dimension value length limits to 255

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 group 'com.dynatrace.metric.util'
-version = '2.4.0'
+version = '2.5.0'
 
 repositories {
     mavenCentral()

--- a/lib/src/main/java/com/dynatrace/metric/util/MetricLineConstants.java
+++ b/lib/src/main/java/com/dynatrace/metric/util/MetricLineConstants.java
@@ -28,9 +28,9 @@ final class MetricLineConstants {
     static final int MAX_DIMENSIONS_COUNT = 50;
 
     // Exceeding these cause the values to be truncated.
-    static final int MAX_METRIC_KEY_LENGTH = 250;
+    static final int MAX_METRIC_KEY_LENGTH = 255;
     static final int MAX_DIMENSION_KEY_LENGTH = 100;
-    static final int MAX_DIMENSION_VALUE_LENGTH = 250;
+    static final int MAX_DIMENSION_VALUE_LENGTH = 255;
   }
 
   /** Constants for Gauge payload creation. */

--- a/lib/src/test/java/com/dynatrace/metric/util/MetricKeyValidatorTest.java
+++ b/lib/src/test/java/com/dynatrace/metric/util/MetricKeyValidatorTest.java
@@ -59,7 +59,7 @@ public class MetricKeyValidatorTest {
         Arguments.of("valid mixture dots underscores 2", "_._._.a_._"),
         Arguments.of("valid combined test", "metric.key-number-1.001"),
         Arguments.of("valid example 1", "MyMetric"),
-        Arguments.of("valid max length key", TestUtils.repeatStringNTimes("a", 250)));
+        Arguments.of("valid max length key", TestUtils.repeatStringNTimes("a", 255)));
   }
 
   private static Stream<Arguments> provideMetricKeys_shouldNormalize() {
@@ -97,6 +97,6 @@ public class MetricKeyValidatorTest {
         Arguments.of("invalid example 3", "metriÄ"),
         Arguments.of("invalid example 4", "Ätric"),
         Arguments.of("invalid example 5", "meträääääÖÖÖc"),
-        Arguments.of("invalid truncate key too long", TestUtils.repeatStringNTimes("a", 251)));
+        Arguments.of("invalid truncate key too long", TestUtils.repeatStringNTimes("a", 256)));
   }
 }

--- a/lib/src/test/java/com/dynatrace/metric/util/NormalizerTest.java
+++ b/lib/src/test/java/com/dynatrace/metric/util/NormalizerTest.java
@@ -156,7 +156,7 @@ public class NormalizerTest {
         Arguments.of(
             "invalid truncate key too long",
             TestUtils.repeatStringNTimes("a", 270),
-            TestUtils.repeatStringNTimes("a", 250)));
+            TestUtils.repeatStringNTimes("a", 255)));
   }
 
   private static Stream<Arguments> provideDimensionKeys() {
@@ -255,7 +255,7 @@ public class NormalizerTest {
         Arguments.of(
             "invalid truncate value too long",
             TestUtils.repeatStringNTimes("a", 270),
-            TestUtils.repeatStringNTimes("a", 250)));
+            TestUtils.repeatStringNTimes("a", 255)));
   }
 
   private static Stream<Arguments> provideUnquotedStringValues() {


### PR DESCRIPTION
Aligns with the metric ingestion protocol spec, which allows keys up to 255 characters.

See https://docs.dynatrace.com/docs/shortlink/metric-ingestion-protocol.